### PR TITLE
Replace standard types by their typing counterparts.

### DIFF
--- a/src/ssl_smtp_handler/__init__.py
+++ b/src/ssl_smtp_handler/__init__.py
@@ -6,18 +6,18 @@ from smtplib import SMTP_SSL
 from smtplib import SMTP_SSL_PORT
 from ssl import SSLContext
 from typing import Optional
-from typing import Union
+from typing import Union, Tuple, List
 
 
 class SSLSMTPHandler(SMTPHandler):
     def __init__(
         self,
-        mailhost: Union[str, tuple[str, int]],
+        mailhost: Union[str, Tuple[str, int]],
         fromaddr: str,
-        toaddrs: list[str],
+        toaddrs: List[str],
         subject: str,
-        credentials: Optional[tuple[str, str]] = None,
-        secure: Optional[Union[tuple[()], tuple[str], tuple[str, str]]] = None,
+        credentials: Optional[Tuple[str, str]] = None,
+        secure: Optional[Union[Tuple[()], Tuple[str], Tuple[str, str]]] = None,
         timeout: float = 1.0,
         context: Optional[SSLContext] = None,
     ) -> None:

--- a/src/ssl_smtp_handler/__init__.py
+++ b/src/ssl_smtp_handler/__init__.py
@@ -57,7 +57,7 @@ class SSLSMTPHandler(SMTPHandler):
         self.username: str
         self.password: str
         self.fromaddr: str
-        self.toaddrs: list[str]
+        self.toaddrs: List[str]
         self.timeout: float
         self.context = context
 


### PR DESCRIPTION
When trying to import the module it raised `TypeError` as python types are not subscriptable. When it comes to type hints, their typing counterparts should be used.